### PR TITLE
Updated fastn-community url to publish this font package

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -1,7 +1,6 @@
 -- import: fastn
 
--- fastn.package: fifthtry.github.io/arya-font
-download-base-url: https://raw.githubusercontent.com/fifthtry/arya-font/main
+-- fastn.package: fastn-community.github.io/arya-font
 
 -- fastn.dependency: fifthtry.github.io/package-doc
 
@@ -15,7 +14,7 @@ download-base-url: https://raw.githubusercontent.com/fifthtry/arya-font/main
 - Custom Font: custom/
 
 # GitHub: 
-  url: https://github.com/fifthtry/arya-font
+  url: https://github.com/fastn-community/arya-font
 
 
 
@@ -25,7 +24,7 @@ download-base-url: https://raw.githubusercontent.com/fifthtry/arya-font/main
 -- fastn.font: Arya
 style: normal
 weight: 400
-woff2: -/fifthtry.github.io/arya-font/static/Arya-400-normal-devanagari.woff2
+woff2: -/fastn-community.github.io/arya-font/static/Arya-400-normal-devanagari.woff2
 unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB
 
 
@@ -34,7 +33,7 @@ unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B
 -- fastn.font: Arya
 style: normal
 weight: 400
-woff2: -/fifthtry.github.io/arya-font/static/Arya-400-normal-latin-ext.woff2
+woff2: -/fastn-community.github.io/arya-font/static/Arya-400-normal-latin-ext.woff2
 unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF
 
 
@@ -43,7 +42,7 @@ unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20C
 -- fastn.font: Arya
 style: normal
 weight: 400
-woff2: -/fifthtry.github.io/arya-font/static/Arya-400-normal-latin.woff2
+woff2: -/fastn-community.github.io/arya-font/static/Arya-400-normal-latin.woff2
 unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
 
 
@@ -52,7 +51,7 @@ unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+
 -- fastn.font: Arya
 style: normal
 weight: 700
-woff2: -/fifthtry.github.io/arya-font/static/Arya-700-normal-devanagari.woff2
+woff2: -/fastn-community.github.io/arya-font/static/Arya-700-normal-devanagari.woff2
 unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB
 
 
@@ -61,7 +60,7 @@ unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B
 -- fastn.font: Arya
 style: normal
 weight: 700
-woff2: -/fifthtry.github.io/arya-font/static/Arya-700-normal-latin-ext.woff2
+woff2: -/fastn-community.github.io/arya-font/static/Arya-700-normal-latin-ext.woff2
 unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF
 
 
@@ -70,7 +69,7 @@ unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20C
 -- fastn.font: Arya
 style: normal
 weight: 700
-woff2: -/fifthtry.github.io/arya-font/static/Arya-700-normal-latin.woff2
+woff2: -/fastn-community.github.io/arya-font/static/Arya-700-normal-latin.woff2
 unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
 
     

--- a/README.md
+++ b/README.md
@@ -3,15 +3,18 @@
 This repository contains a [fastn font package](https://fpm.dev/featured/fonts/) containing [Google Font: 
 Arya](https://fonts.google.com/specimen/Arya/about).
 
-Arya is a Devanagari and Latin type family. It originated with Modular InfoTech's 1201, and was made more smooth. The 
-new and original Latin design is intended to match the Devanagari in weight and and size with an unusual high-contrast 
-sans serif design.
+Arya is a Devanagari and Latin type family. It originated with Modular
+InfoTech's 1201, and was made more smooth. The new and original Latin design is
+intended to match the Devanagari in weight and and size with an unusual
+high-contrast sans serif design.
 
 Designers: Eduardo Tunni, Principal design
 
 ## How To Use This Font In Your fastn Package:
 
 [Read the docs and demo](https://fastn-community.github.io/arya-font/).
+
+Also, check [arya-font-typography](https://fastn-community.github.io/arya-font-typograph)
 
 ## 👀 Want to learn more?
 

--- a/custom.ftd
+++ b/custom.ftd
@@ -1,11 +1,11 @@
--- import: fifthtry.github.io/arya-font/assets as arya-font-assets
+-- import: fastn-community.github.io/arya-font/assets as arya-font-assets
 -- import: fifthtry.github.io/package-doc/doc as pd
 -- import: fifthtry.github.io/package-doc/forest-theme as ds
 -- import: fifthtry.github.io/package-doc/footer
 
 ;; ⚠️fastn-builders::⚠️ before using this file please find and replace Arya
 ;; with font name you have given inside 
-;; `fifthtry.github.io/arya-font/FASTN.ftd file
+;; `fastn-community.github.io/arya-font/FASTN.ftd file
 
 
 
@@ -23,7 +23,7 @@ site-name: `arya-font` Font Package
 -- end: ds.page.footer
 
 -- pd.package: FTD arya-font package
-name: fifthtry.github.io/arya-font
+name: fastn-community.github.io/arya-font
 
 This FTD font `arya-font` package is for your ftd web projects. To Use this
 arya-font inside `FTD` project follow below instructions.
@@ -33,7 +33,7 @@ arya-font inside `FTD` project follow below instructions.
 -- ds.code: Add this to your FASTN.ftd
 lang: ftd
 
-\-- fastn.dependency: fifthtry.github.io/arya-font
+\-- fastn.dependency: fastn-community.github.io/arya-font
 
 -- ds.markdown: 
 
@@ -45,7 +45,7 @@ follow below instructions.
 -- ds.code:
 lang: ftd
 
-\-- import: fifthtry.github.io/arya-font/assets as arya-font-assets
+\-- import: fastn-community.github.io/arya-font/assets as arya-font-assets
 
 
 -- ds.h3: How to create a custom arya-font type? 
@@ -55,11 +55,11 @@ lang: ftd
 How to use `ftd.type` to create a custom font `types` using arya-font? 
 
 We don't recommend creating custom types. We recommend to use 
-our [arya-font-typography](fifthtry.github.io/arya-font-typography)
+our [arya-font-typography](fastn-community.github.io/arya-font-typography)
 
-If you're using [arya-font-typography](fifthtry.github.io/arya-font-typography) 
+If you're using [arya-font-typography](fastn-community.github.io/arya-font-typography) 
 and still your designer has introduced new font size which is not included or 
-part of our [arya-font-typography](fifthtry.github.io/arya-font-typography) 
+part of our [arya-font-typography](fastn-community.github.io/arya-font-typography) 
 then only define custom types. 
 
 We hope you shouldn't need to define a custom type.

--- a/index.ftd
+++ b/index.ftd
@@ -1,6 +1,6 @@
 -- import: fifthtry.github.io/package-doc/doc as pd
 -- import: fifthtry.github.io/package-doc/forest-theme as ds
--- import: fifthtry.github.io/arya-font/custom
+-- import: fastn-community.github.io/arya-font/custom
 -- import: fifthtry.github.io/package-doc/footer
 
 
@@ -17,11 +17,11 @@ site-name: `arya-font` Font Package
 -- end: ds.page.footer
 
 -- pd.package: FTD arya-font package
-name: fifthtry.github.io/arya-font
+name: fastn-community.github.io/arya-font
 
 This FTD font `arya-font` can be used for your ftd web projects. 
 
-To Use this arya-font inside `FTD` project visit [arya-font-typography](https://fifthtry.github.io/arya-font-typography).
+To Use this arya-font inside `FTD` project visit [arya-font-typography](https://fastn-community.github.io/arya-font-typography).
 
 -- ds.h3: arya-font various sizes
 


### PR DESCRIPTION
As this font is moved from https://github.com/FifthTry/arya-font to this `fastn-community` package name and font url should be updated to new location.